### PR TITLE
Renamed plugin file & class name

### DIFF
--- a/roundcube_nonce_login.php
+++ b/roundcube_nonce_login.php
@@ -8,7 +8,7 @@
  * @version @package_version@
  * @author Patrick Gansterer <paroga@paroga.com>
  */
-class nonce_login extends rcube_plugin
+class roundcube_nonce_login extends rcube_plugin
 {
     // registered tasks for this plugin.
     public $task = 'login';


### PR DESCRIPTION
Fix for Issue: https://github.com/paroga/roundcube-nonce_login/issues/1